### PR TITLE
Add obsoletes to spec file

### DIFF
--- a/csp-billing-adapter-amazon.spec
+++ b/csp-billing-adapter-amazon.spec
@@ -43,6 +43,7 @@ Requires:       python-pluggy
 Requires:       python-boto3
 Requires:       python-csp-billing-adapter
 BuildArch:      noarch
+Obsoletes:      python3-csp-billing-adapter-amazon < %{version}
 %python_subpackages
 
 %description


### PR DESCRIPTION
The package builds for python 3.## version instead of only python3